### PR TITLE
build: fix bashisms in configure

### DIFF
--- a/oac_check_package.m4
+++ b/oac_check_package.m4
@@ -423,7 +423,7 @@ AC_DEFUN([_OAC_CHECK_PACKAGE_WRAPPER_COMPILER], [
     m4_ifdef([$1_wrapper_compiler],
              [m4_define([wrapper_compiler_name], [$1_wrapper_compiler])],
              [m4_define([wrapper_compiler_name], [$1cc])])
-    AS_IF([test "${$1_USE_WRAPPER_COMPILER}" == "1"],
+    AS_IF([test "${$1_USE_WRAPPER_COMPILER}" = "1"],
           [# search for the package using wrapper compilers.  If the user
            # provided a --with-$1 argument, be explicit about where we look
            # for the compiler, so we don't find the wrong one.


### PR DESCRIPTION
configure scripts need to be runnable with a POSIX-compliant /bin/sh.

On many (but not all!) systems, /bin/sh is provided by Bash, so errors like this aren't spotted. Notably Debian defaults to /bin/sh provided by dash which doesn't tolerate such bashisms as '=='.

This retains compatibility with bash.

Signed-off-by: Sam James <sam@gentoo.org>