### PR TITLE
oac_check_package: Adding library path to LDFLAGS

### DIFF
--- a/oac_check_package.m4
+++ b/oac_check_package.m4
@@ -625,7 +625,7 @@ disambiguate.])],
                          AC_MSG_RESULT([found -- lib])],
                         [test $check_package_generic_prefix_lib64 -eq 1],
                         [check_package_generic_prefix_happy=1
-                         libdir_prefix=${check_package_prefix}/lib64
+                         $2_LDFLAGS=-L${check_package_prefix}/lib64
                          AC_MSG_RESULT([found -- lib64])],
                         [AC_MSG_RESULT([not found])])])])
 


### PR DESCRIPTION
oac_check_package checks if the "lib64" directory exists but it does not update LDFLAGS.