### PR TITLE
Remove solaris checks

### DIFF
--- a/oac_check_os_flavors.m4
+++ b/oac_check_os_flavors.m4
@@ -5,7 +5,7 @@ dnl Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
 dnl Copyright (c) 2014      Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
 dnl
-dnl Copyright (c) 2022-2023 Nanook Consulting.  All rights reserved.
+dnl Copyright (c) 2022-2025 Nanook Consulting  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -45,19 +45,6 @@ AC_DEFUN([OAC_CHECK_OS_FLAVORS],
     OAC_CHECK_OS_FLAVOR_SPECIFIC([__bsdi__], [bsdi])
     OAC_CHECK_OS_FLAVOR_SPECIFIC([__APPLE__], [apple])
     OAC_CHECK_OS_FLAVOR_SPECIFIC([__linux__], [linux])
-    OAC_CHECK_OS_FLAVOR_SPECIFIC([__sun__], [sun])
-    AS_IF([test "$oac_found_sun" = "no"],
-          OAC_CHECK_OS_FLAVOR_SPECIFIC([__sun], [sun]))
-
-    AS_IF([test "$oac_found_sun" = "yes"],
-          [oac_have_solaris=1
-           CFLAGS="$CFLAGS -D_REENTRANT"
-           CPPFLAGS="$CPPFLAGS -D_REENTRANT"],
-          [oac_have_solaris=0])
-    AC_DEFINE_UNQUOTED([OAC_HAVE_SOLARIS],
-                       [$oac_have_solaris],
-                       [Whether or not we have solaris])
-    AM_CONDITIONAL(OAC_HAVE_SOLARIS, test "$oac_have_solaris" = "1")
 
     AS_IF([test "$oac_found_apple" = "yes"],
           [oac_have_apple=1],


### PR DESCRIPTION
We no longer support the solaris environment, so remove the checks for it