### PR TITLE
Fix correctness, quoting, caching, and scope bugs across all OAC macros

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # How to contribute to the OAC project
 
 First off, thank you for taking the time to prepare a contribution to
-the Open Autconf macros project!
+the Open Autoconf macros project!
 
 ![You're awesome!](https://www.open-mpi.org/images/youre-awesome.jpg)
 

--- a/.github/workflows/git-commit-checks.py
+++ b/.github/workflows/git-commit-checks.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
 
 """
 
@@ -12,7 +13,6 @@ variables that are available in the Github Action environment.  Specifically:
 * GITHUB_HEAD_REF: the git commit ref of the head branch
 * GITHUB_TOKEN: token authorizing Github API usage
 * GITHUB_REPOSITORY: "org/repo" name of the Github repository of this PR
-* GITHUB_REF: string that includes this Github PR number
 * GITHUB_RUN_ID: unique ID for each workflow run
 * GITHUB_SERVER_URL: the URL of the GitHub server
 
@@ -45,8 +45,6 @@ import re
 import git
 import json
 import copy
-import argparse
-
 from github import Github
 
 GOOD = "good"
@@ -61,7 +59,6 @@ GITHUB_BASE_REF   = os.environ.get('GITHUB_BASE_REF')
 GITHUB_HEAD_REF   = os.environ.get('GITHUB_HEAD_REF')
 GITHUB_TOKEN      = os.environ.get('GITHUB_TOKEN')
 GITHUB_REPOSITORY = os.environ.get('GITHUB_REPOSITORY')
-GITHUB_REF        = os.environ.get('GITHUB_REF')
 GITHUB_RUN_ID     = os.environ.get('GITHUB_RUN_ID')
 GITHUB_SERVER_URL = os.environ.get('GITHUB_SERVER_URL')
 PR_NUM            = os.environ.get('PR_NUM')
@@ -72,7 +69,6 @@ if (GITHUB_WORKSPACE is None or
     GITHUB_HEAD_REF is None or
     GITHUB_TOKEN is None or
     GITHUB_REPOSITORY is None or
-    GITHUB_REF is None or
     GITHUB_RUN_ID is None or
     GITHUB_SERVER_URL is None or
     PR_NUM is None):
@@ -84,8 +80,8 @@ if (GITHUB_WORKSPACE is None or
 """
 Simple helper to make a 1-line git commit message summary.
 """
-def make_commit_message(repo, hash):
-    commit  = repo.commit(hash)
+def make_commit_message(repo, commit_hash):
+    commit  = repo.commit(commit_hash)
     lines   = commit.message.split('\n')
     message = lines[0][:50]
     if len(lines[0]) > 50:
@@ -110,8 +106,8 @@ def comment_on_pr(pr, results, repo):
         return
 
     comment = "Hello! The Git Commit Checker CI bot found a few problems with this PR:"
-    for hash, entry in results[BAD].items():
-        comment += f"\n\n**{hash[:8]}: {make_commit_message(repo, hash)}**"
+    for commit_hash, entry in results[BAD].items():
+        comment += f"\n\n**{commit_hash[:8]}: {make_commit_message(repo, commit_hash)}**"
         for check_name, message in entry.items():
             if message is not None:
                 comment += f"\n  * *{check_name}: {message}*"
@@ -148,10 +144,10 @@ If the message is None, there's nothing to print.
 
 A git commit hash will be in either the GOOD or the BAD results -- not both.
 """
-def print_results(results, repo, hashes):
+def print_results(results, repo):
     def _print_list(entries, prefix=""):
-        for hash, entry in entries.items():
-            print(f"{prefix}* {hash[:8]}: {make_commit_message(repo, hash)}")
+        for commit_hash, entry in entries.items():
+            print(f"{prefix}* {commit_hash[:8]}: {make_commit_message(repo, commit_hash)}")
             for check_name, message in entry.items():
                 if message is not None:
                     print(f"{prefix}    * {check_name}: {message}")
@@ -181,7 +177,7 @@ def check_signed_off(config, repo, commit):
     # merge, don't require a signed-off-by
     if commit.message.startswith("Revert "):
         return GOOD, "skipped (revert)"
-    elif len(commit.parents) == 2:
+    elif len(commit.parents) >= 2:
         return GOOD, "skipped (merge)"
 
     matches = prog_sob.search(commit.message)
@@ -194,15 +190,15 @@ def check_signed_off(config, repo, commit):
 
 def check_email(config, repo, commit):
     emails = {
-        "author"    : commit.author.email.lower(),
-        "committer" : commit.committer.email.lower(),
+        "author"    : (commit.author.email or "").lower(),
+        "committer" : (commit.committer.email or "").lower(),
     }
 
-    for id, email in emails.items():
+    for committer_id, email in emails.items():
         for pattern in config['bad emails']:
             match = re.search(pattern, email)
             if match:
-                return BAD, f"{id} email address ({email}) contains '{pattern}'"
+                return BAD, f"{committer_id} email address ({email}) contains '{pattern}'"
 
     return GOOD, None
 
@@ -212,13 +208,13 @@ def check_email(config, repo, commit):
 Global regexp, because we use it every time we call check_cherry_pick()
 (i.e., for each commit in this PR)
 """
-prog_cp = re.compile(r'\(cherry picked from commit ([a-z0-9]+)\)')
+prog_cp = re.compile(r'\(cherry picked from commit ([0-9a-fA-F]+)\)')
 
 def check_cherry_pick(config, repo, commit):
     def _is_entirely_submodule_updates(repo, commit):
-        # If it's a merge commit, that doesn't fit our definition of
-        # "entirely submodule updates"
-        if len(commit.parents) == 2:
+        # If it's a merge commit or initial commit, that doesn't fit our
+        # definition of "entirely submodule updates"
+        if len(commit.parents) != 1:
             return False
 
         # Check the diffs of this commit compared to the prior commit,
@@ -237,7 +233,7 @@ def check_cherry_pick(config, repo, commit):
     # If this commit is solely comprised of submodule updates, don't
     # require a cherry pick message.
     if len(repo.submodules) > 0 and _is_entirely_submodule_updates(repo, commit):
-        return GOOD, "skipped (submodules updates)"
+        return GOOD, "skipped (submodule updates)"
 
     non_existent = dict()
     unmerged = dict()
@@ -245,7 +241,7 @@ def check_cherry_pick(config, repo, commit):
     for match in prog_cp.findall(commit.message):
         found_cherry_pick_line = True
         try:
-            c = repo.commit(match)
+            repo.commit(match)
         except ValueError as e:
             # These errors mean that the git library recognized the
             # hash as a valid commit, but the GitHub Action didn't
@@ -268,24 +264,24 @@ def check_cherry_pick(config, repo, commit):
         if len(non_existent) == 0 and len(unmerged) == 0:
             return GOOD, None
         elif len(non_existent) > 0 and len(unmerged) == 0:
-            str = f"contains a cherry pick message that refers to non-existent commit"
+            msg = f"contains a cherry pick message that refers to non-existent commit"
             if len(non_existent) > 1:
-                str += "s"
-            str += ": "
-            str += ", ".join(non_existent)
-            return BAD, str
+                msg += "s"
+            msg += ": "
+            msg += ", ".join(non_existent)
+            return BAD, msg
         elif len(non_existent) == 0 and len(unmerged) > 0:
-            str = f"contains a cherry pick message that refers to a commit that exists, but is in an as-yet unmerged pull request"
-            if len(non_existent) > 1:
-                str += "s"
-            str += ": "
-            str += ", ".join(unmerged)
-            return BAD, str
+            msg = f"contains a cherry pick message that refers to a commit that exists, but is in an as-yet unmerged pull request"
+            if len(unmerged) > 1:
+                msg += "s"
+            msg += ": "
+            msg += ", ".join(unmerged)
+            return BAD, msg
         else:
-            str = f"contains a cherry pick message that refers to both non-existent commits and commits that exist but are in as-yet unmerged pull requests"
-            str += ": "
-            str += ", ".join(non_existent + unmerged)
-            return BAD, str
+            msg = f"contains a cherry pick message that refers to both non-existent commits and commits that exist but are in as-yet unmerged pull requests"
+            msg += ": "
+            msg += ", ".join(list(non_existent) + list(unmerged))
+            return BAD, msg
 
     else:
         if config['cherry pick required']:
@@ -313,22 +309,22 @@ def check_all_commits(config, repo):
     # Make an empty set of nested dictionaries to fill in, below. We initially
     # create a "full" template dictionary (with all the hashes for both GOOD and
     # BAD results), but will trim some of them later.
-    template = { hash : dict() for hash in hashes }
+    template = { commit_hash : dict() for commit_hash in hashes }
     results  = {
         GOOD : copy.deepcopy(template),
         BAD  : copy.deepcopy(template),
     }
 
-    for hash in hashes:
+    for commit_hash in hashes:
         overall = GOOD
 
         # Do the checks on this commit
-        commit  = repo.commit(hash)
+        commit  = repo.commit(commit_hash)
         for check_fn in [check_signed_off, check_email, check_cherry_pick]:
             result, message = check_fn(config, repo, commit)
             overall         = BAD if result == BAD else overall
 
-            results[result][hash][check_fn.__name__] = message
+            results[result][commit_hash][check_fn.__name__] = message
 
         # Trim the results dictionary so that a hash only appears in GOOD *or*
         # BAD -- not both. Specifically:
@@ -336,11 +332,11 @@ def check_all_commits(config, repo):
         # 1. If a hash has BAD results, delete all of its results from GOOD.
         # 2. If a hash has only GOOD results, delete its empty entry from BAD.
         if overall == BAD:
-            del results[GOOD][hash]
+            del results[GOOD][commit_hash]
         else:
-            del results[BAD][hash]
+            del results[BAD][commit_hash]
 
-    return results, hashes
+    return results
 
 #----------------------------------------------------------------------------
 
@@ -390,14 +386,22 @@ def main():
 
     check_github_pr_description(config, pr)
 
+    if pr.head.repo is None:
+        print("Error: head repository is no longer available (fork deleted?)")
+        exit(1)
+
     # Because we're using pull_request_target, we cloned the base repo and
     # therefore have to add the head repo as a remote.
     local_repo = git.Repo(GITHUB_WORKSPACE)
-    head_remote = git.remote.Remote.create(local_repo, GIT_REMOTE_PR_HEAD_NAME, pr.head.repo.clone_url)
+    if GIT_REMOTE_PR_HEAD_NAME in [r.name for r in local_repo.remotes]:
+        head_remote = local_repo.remote(GIT_REMOTE_PR_HEAD_NAME)
+        head_remote.set_url(pr.head.repo.clone_url)
+    else:
+        head_remote = git.remote.Remote.create(local_repo, GIT_REMOTE_PR_HEAD_NAME, pr.head.repo.clone_url)
     head_remote.fetch()
 
-    results, hashes = check_all_commits(config, local_repo)
-    print_results(results, local_repo, hashes)
+    results = check_all_commits(config, local_repo)
+    print_results(results, local_repo)
     comment_on_pr(pr, results, local_repo)
 
     if len(results[BAD]) == 0:

--- a/.github/workflows/git-commit-checks.py
+++ b/.github/workflows/git-commit-checks.py
@@ -206,9 +206,14 @@ def check_email(config, repo, commit):
 
 """
 Global regexp, because we use it every time we call check_cherry_pick()
-(i.e., for each commit in this PR)
+(i.e., for each commit in this PR).
+The capture group intentionally matches any lowercase alphanumeric string,
+not just strict hex digits: a malformed hash (e.g., containing 'g'-'z')
+would still be captured and then rejected by repo.commit() with git.BadName,
+producing the correct "non-existent commit" error rather than silently
+skipping the trailer.
 """
-prog_cp = re.compile(r'\(cherry picked from commit ([0-9a-fA-F]+)\)')
+prog_cp = re.compile(r'\(cherry picked from commit ([a-z0-9]+)\)')
 
 def check_cherry_pick(config, repo, commit):
     def _is_entirely_submodule_updates(repo, commit):
@@ -242,6 +247,13 @@ def check_cherry_pick(config, repo, commit):
         found_cherry_pick_line = True
         try:
             repo.commit(match)
+        except git.BadName as e:
+            # Use a dictionary to track the non-existent hashes, just
+            # on the off chance that the same non-existent hash exists
+            # more than once in a single commit message (i.e., the
+            # dictionary will effectively give us de-duplication for
+            # free).
+            non_existent[match] = True
         except ValueError as e:
             # These errors mean that the git library recognized the
             # hash as a valid commit, but the GitHub Action didn't
@@ -251,13 +263,6 @@ def check_cherry_pick(config, repo, commit):
             # want to fail this commit until the corresponding pull request
             # is merged.
             unmerged[match] = True
-        except git.BadName as e:
-            # Use a dictionary to track the non-existent hashes, just
-            # on the off chance that the same non-existent hash exists
-            # more than once in a single commit message (i.e., the
-            # dictionary will effectively give us de-duplication for
-            # free).
-            non_existent[match] = True
 
     # Process the results for this commit
     if found_cherry_pick_line:

--- a/.github/workflows/git-commit-checks.yaml
+++ b/.github/workflows/git-commit-checks.yaml
@@ -1,3 +1,4 @@
+# Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
 name: GitHub Action CI
 
 # We're using pull_request_target here instead of just pull_request so that the
@@ -23,13 +24,13 @@ jobs:
         runs-on: ubuntu-latest
         steps:
           - name: Check out the code
-            uses: actions/checkout@v2
+            uses: actions/checkout@v4
             with:
                 # Get all branches and history
                 fetch-depth: 0
 
           - name: Setup Python
-            uses: actions/setup-python@v2
+            uses: actions/setup-python@v4
             with:
               python-version: '3.x'
 

--- a/oac_assert.m4
+++ b/oac_assert.m4
@@ -4,6 +4,8 @@ dnl Copyright (c) 2022      Amazon.com, Inc. or its affiliates.  All Rights rese
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
+dnl
+dnl $HEADER$
 
 
 dnl OAC_ASSERT_LITERAL: Assert if first argument is not an Autoconf literal

--- a/oac_check_os_flavors.m4
+++ b/oac_check_os_flavors.m4
@@ -6,6 +6,7 @@ dnl Copyright (c) 2014      Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
 dnl
 dnl Copyright (c) 2022-2025 Nanook Consulting  All rights reserved.
+dnl Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -15,7 +16,7 @@ dnl
 
 # OAC_CHECK_OS_FLAVOR_SPECIFIC()
 # ----------------------------------------------------
-# Helper macro from OAC-CHECK-OS-FLAVORS(), below.
+# Helper macro from OAC_CHECK_OS_FLAVORS(), below.
 # $1 = macro to look for
 # $2 = suffix of env variable to set with results
 AC_DEFUN([OAC_CHECK_OS_FLAVOR_SPECIFIC],
@@ -52,6 +53,6 @@ AC_DEFUN([OAC_CHECK_OS_FLAVORS],
     AC_DEFINE_UNQUOTED([OAC_HAVE_APPLE],
                        [$oac_have_apple],
                        [Whether or not we have apple])
-    AM_CONDITIONAL(OAC_HAVE_APPLE, test "$oac_have_apple" = "1")
+    AM_CONDITIONAL([OAC_HAVE_APPLE], [test "$oac_have_apple" = "1"])
 
 ])dnl

--- a/oac_check_package.m4
+++ b/oac_check_package.m4
@@ -2,6 +2,7 @@ dnl -*- autoconf -*-
 dnl
 dnl Copyright (c) 2022      Amazon.com, Inc. or its affiliates.  All Rights reserved.
 dnl Copyright (c) 2022      Nanook Consulting.  All rights reserved.
+dnl Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -43,7 +44,7 @@ dnl   4. We try to find the specified header and function with no change
 dnl      in CPPFLAGS or LDFLAGS and adding the specified libraries to LIBS.
 dnl
 dnl It is the responsibility of the caller to register arguments of the form
-dnl with-<package name>, with-<package name>-libdir, and with-package name>-incdir.
+dnl with-<package name>, with-<package name>-libdir, and with-<package name>-incdir.
 dnl All three are optional, nothing will break if the caller doesn't specify them
 dnl (and indeed, if the package being searched for isn't libnl3, it's likely the
 dnl with-<package name>-incdir is a complete waste of energy).
@@ -100,7 +101,7 @@ AC_DEFUN([OAC_CHECK_PACKAGE],[
     AC_REQUIRE([_OAC_CHECK_PACKAGE_STATIC_CHECK])
     OAC_ASSERT_LITERAL([$1])dnl
     OAC_ASSERT_LITERAL([$2])dnl
-    OAC_VAR_SCOPE_PUSH([check_package_$2_save_CPPFLAGS check_package_$2_save_LDFLAGS check_package_$2_save_LIBS check_package_happy check_package_have_flags check_package_prefix check_package_libdir check_package_incdir check_package_pcfilename])
+    OAC_VAR_SCOPE_PUSH([check_package_$2_save_CPPFLAGS check_package_$2_save_LDFLAGS check_package_$2_save_LIBS check_package_happy check_package_have_flags check_package_prefix check_package_libdir check_package_incdir check_package_type])
 
     check_package_$2_save_CPPFLAGS="${CPPFLAGS}"
     check_package_$2_save_LDFLAGS="${LDFLAGS}"
@@ -178,6 +179,7 @@ AC_DEFUN([OAC_CHECK_PACKAGE],[
            AS_UNSET([$2_STATIC_LDFLAGS])
            AS_UNSET([$2_LIBS])
            AS_UNSET([$2_STATIC_LIBS])
+           AS_UNSET([$2_PC_MODULES])
            $7])
 
     CPPFLAGS="${check_package_$2_save_CPPFLAGS}"
@@ -236,7 +238,8 @@ AC_DEFUN([OAC_CHECK_PACKAGE_PARSE_PKGCONFIG], [
     # that a hard failure.  It should not happen, outside of a weird system configuration
     # issue where we're probably not going to like the results anyway.
     AS_IF([test "${oac_cv_check_package_$1_pkg_config_exists}" = "yes"],
-          [AC_CACHE_CHECK([for $1 pkg-config cflags],
+          [$2_PC_MODULES=$3
+           AC_CACHE_CHECK([for $1 pkg-config cflags],
                 [oac_cv_check_package_$1_pkg_config_cppflags],
                 [_OAC_CHECK_PACKAGE_PKGCONFIG_RUN([$3], [--cflags],
                       [oac_cv_check_package_$1_pkg_config_cppflags], [],
@@ -363,8 +366,8 @@ dnl 2 -> prefix
 dnl 3 -> action if found flags
 AC_DEFUN([_OAC_CHECK_PACKAGE_PKGCONFIG], [
     m4_ifdef([$1_pkgconfig_module],
-             [m4_define([pcname], [$1_pkgconfig_module])],
-             [m4_define([pcname], [$1])])
+             [m4_pushdef([pcname], [$1_pkgconfig_module])],
+             [m4_pushdef([pcname], [$1])])
     AS_IF([test "${$1_USE_PKG_CONFIG}" != "0"],
           [# search for the package using pkg-config.  If the user provided a
            # --with-$1 or --with-$1-libdir argument, be explicit about where
@@ -385,11 +388,12 @@ AC_DEFUN([_OAC_CHECK_PACKAGE_PKGCONFIG], [
                              [AC_MSG_ERROR([Found pcname in both ${check_package_prefix}/lib/pkgconfig and
 ${check_package_prefix}/lib64/pkgconfig.  This is confusing.  Please add --with-$1-libdir=PATH
 to configure to help disambiguate.])],
-                             [check_package_cv_$1_pcfilename="${check_package_prefix}/lib/pkgconfig/pcname.pc"])],
+                             [oac_cv_check_package_$1_pcfilename="${check_package_prefix}/lib/pkgconfig/pcname.pc"])],
                       [test -r "${check_package_prefix}/lib64/pkgconfig/pcname.pc"],
                       [oac_cv_check_package_$1_pcfilename="${check_package_prefix}/lib64/pkgconfig/pcname.pc"],
                       [oac_cv_check_package_$1_pcfilename="${check_package_prefix}/lib/pkgconfig/pcname.pc"])])
          OAC_CHECK_PACKAGE_PARSE_PKGCONFIG([$1], [$2], [${oac_cv_check_package_$1_pcfilename}], [$3])])
+    m4_popdef([pcname])
 ])
 
 
@@ -402,10 +406,10 @@ AC_DEFUN([_OAC_CHECK_PACKAGE_PKGCONFIG_RUN], [
     OAC_VAR_SCOPE_PUSH([check_package_pkgconfig_run_results check_package_pkgconfig_run_happy])
     check_package_pkgconfig_run_happy=no
     AS_IF([test -n "${PKG_CONFIG}"],
-          [OAC_LOG_COMMAND([check_package_pkgconfig_run_results=`${PKG_CONFIG} $2 $1 2>&1`],
+          [OAC_LOG_COMMAND([check_package_pkgconfig_run_results=`${PKG_CONFIG} $2 "$1" 2>&1`],
                [AS_VAR_COPY([$3], [check_package_pkgconfig_run_results])
                 check_package_pkgconfig_run_happy=yes])
-           OAC_LOG_MSG([pkg-config output: ${check_package_pkgconfig_run_results}], [1])])
+           OAC_LOG_MSG([pkg-config output: ${check_package_pkgconfig_run_results}])])
     AS_IF([test "${check_package_pkgconfig_run_happy}" = "yes"], [$4], [$5])
     OAC_VAR_SCOPE_POP
 ])
@@ -421,8 +425,8 @@ dnl
 dnl wrapper compiler is off by default; must be explicitly enabled
 AC_DEFUN([_OAC_CHECK_PACKAGE_WRAPPER_COMPILER], [
     m4_ifdef([$1_wrapper_compiler],
-             [m4_define([wrapper_compiler_name], [$1_wrapper_compiler])],
-             [m4_define([wrapper_compiler_name], [$1cc])])
+             [m4_pushdef([wrapper_compiler_name], [$1_wrapper_compiler])],
+             [m4_pushdef([wrapper_compiler_name], [$1cc])])
     AS_IF([test "${$1_USE_WRAPPER_COMPILER}" = "1"],
           [# search for the package using wrapper compilers.  If the user
            # provided a --with-$1 argument, be explicit about where we look
@@ -433,13 +437,14 @@ AC_DEFUN([_OAC_CHECK_PACKAGE_WRAPPER_COMPILER], [
                        [oac_cv_check_package_$1_wrapper_compiler="wrapper_compiler_name"],
                        [oac_cv_check_package_$1_wrapper_compiler="${check_package_prefix}/bin/wrapper_compiler_name"])])
            _OAC_CHECK_PACKAGE_WRAPPER_INTERNAL([$1], [$2], [${oac_cv_check_package_$1_wrapper_compiler}], [$3])])
+    m4_popdef([wrapper_compiler_name])
 ])
 
 
 dnl 1 -> package name
 dnl 2 -> prefix
-dnl 2 -> wrapper compiler
-dnl 3 -> action if found flag
+dnl 3 -> wrapper compiler
+dnl 4 -> action if found flag
 AC_DEFUN([_OAC_CHECK_PACKAGE_WRAPPER_INTERNAL], [
     OAC_VAR_SCOPE_PUSH([check_package_wrapper_internal_result check_package_wrapper_internal_tmp])
 
@@ -452,7 +457,7 @@ AC_DEFUN([_OAC_CHECK_PACKAGE_WRAPPER_INTERNAL], [
     # if wrapper --showme:version  works, but getting one of the standard flags fails, we consider
     # that a hard failure.  It should not happen, outside of a weird system configuration
     # issue where we're probably not going to like the results anyway.
-    AS_IF([test ${oac_cv_check_package_$1_wrapper_compiler_works} = "yes"],
+    AS_IF([test "${oac_cv_check_package_$1_wrapper_compiler_works}" = "yes"],
           [AC_CACHE_CHECK([for $1 wrapper compiler cppflags],
                 [oac_cv_check_package_$1_wrapper_compiler_cppflags],
                 [_OAC_CHECK_PACKAGE_WRAPPER_RUN([$3], [--showme:incdirs],
@@ -495,7 +500,7 @@ AC_DEFUN([_OAC_CHECK_PACKAGE_WRAPPER_INTERNAL], [
                        done],
                       [AC_MSG_RESULT([error])
                        AC_MSG_ERROR([An error occurred retrieving $1 libs from wrapper compiler])])])
-           $2_LIBS="$oac_cv_check_package_$1_wrapper_compiler_libs"
+           $2_LIBS="${oac_cv_check_package_$1_wrapper_compiler_libs}"
 
            AC_CACHE_CHECK([for $1 wrapper compiler static libs],
                 [oac_cv_check_package_$1_wrapper_compiler_static_libs],
@@ -520,11 +525,11 @@ dnl 4 -> action if found
 dnl 5 -> action if failed
 AC_DEFUN([_OAC_CHECK_PACKAGE_WRAPPER_RUN], [
     OAC_VAR_SCOPE_PUSH([check_package_wrapper_run_results])
-    OAC_LOG_COMMAND([check_package_wrapper_run_results=`$1 $2 2>&1`],
+    OAC_LOG_COMMAND([check_package_wrapper_run_results=`"$1" $2 2>&1`],
              [AS_VAR_COPY([$3], [check_package_wrapper_run_results])
               $4],
              [$5])
-         OAC_LOG_MSG([wrapper output: ${check_package_wrapper_run_results}], [1])
+         OAC_LOG_MSG([wrapper output: ${check_package_wrapper_run_results}])
     OAC_VAR_SCOPE_POP
 ])
 
@@ -544,13 +549,13 @@ AC_DEFUN([_OAC_CHECK_PACKAGE_GENERIC], [
     AS_IF([test -n "${check_package_prefix}" || test -n "${check_package_incdir}" || test -n "${check_package_libdir}"],
           [_OAC_CHECK_PACKAGE_GENERIC_PREFIX([$1], [$2], [$3], [$4], [check_package_generic_happy=1])],
           [AC_MSG_NOTICE([Searching for $1 in default search paths])
-           $1_CPPFLAGS=
-           $1_LDFLAGS=
+           $2_CPPFLAGS=
+           $2_LDFLAGS=
            check_package_generic_happy=1])
 
     AS_IF([test ${check_package_generic_happy} -eq 1],
           [for check_package_generic_lib in $4 ; do
-               check_package_generic_lib=`echo ${check_package_generic_lib} | sed -e 's/^-l//'`
+               check_package_generic_lib=`echo "${check_package_generic_lib}" | sed 's/^-l//'`
                OAC_APPEND([$2_LIBS], ["-l${check_package_generic_lib}"])
                OAC_APPEND([$2_STATIC_LIBS], ["-l${check_package_generic_lib}"])
            done
@@ -575,38 +580,42 @@ dnl 3 -> headers (space separated list)
 dnl 4 -> libraries (space separated list)
 dnl 5 -> action if found flags
 AC_DEFUN([_OAC_CHECK_PACKAGE_GENERIC_PREFIX], [
-    OAC_VAR_SCOPE_PUSH([check_package_generic_search_header check_package_generic_search_lib check_package_generic_incdir])
+    OAC_VAR_SCOPE_PUSH([check_package_generic_search_header check_package_generic_search_lib check_package_generic_incdir check_package_generic_prefix_happy check_package_generic_prefix_lib check_package_generic_prefix_lib64])
 
     check_package_generic_search_header=`echo "$3" | cut -f1 -d' '`
-    check_package_generic_search_lib=`echo "$4" | cut -f1 -d' ' | sed -e 's/^-l//'`
+    check_package_generic_search_lib=`echo "$4" | cut -f1 -d' ' | sed 's/^-l//'`
 
     check_package_generic_prefix_happy=0
     AS_IF([test -n "${check_package_incdir}"],
           [check_package_generic_incdir="${check_package_incdir}"],
+          [test -n "${check_package_prefix}"],
           [check_package_generic_incdir="${check_package_prefix}/include"])
-    AC_MSG_CHECKING([for $1 header at ${check_package_generic_incdir}])
-    AS_IF([test -r ${check_package_generic_incdir}/${check_package_generic_search_header}],
-          [check_package_generic_prefix_happy=1
-           $2_CPPFLAGS="-I${check_package_generic_incdir}"
-           AC_MSG_RESULT([found])],
-          [AC_MSG_RESULT([not found])])
+    AS_IF([test -n "${check_package_generic_incdir}"],
+          [AC_MSG_CHECKING([for $1 header at ${check_package_generic_incdir}])
+           AS_IF([test -r "${check_package_generic_incdir}/${check_package_generic_search_header}"],
+                 [check_package_generic_prefix_happy=1
+                  $2_CPPFLAGS="-I${check_package_generic_incdir}"
+                  AC_MSG_RESULT([found])],
+                 [AC_MSG_RESULT([not found])])],
+          [check_package_generic_prefix_happy=1])
 
     AS_IF([test ${check_package_generic_prefix_happy} -eq 1],
           [check_package_generic_prefix_happy=0
            AS_IF([test -n "${check_package_libdir}"],
                  [AC_MSG_CHECKING([for $1 library (${check_package_generic_search_lib}) in ${check_package_libdir}])
-                  ls ${check_package_libdir}/lib${check_package_generic_search_lib}.*  >/dev/null 2>&1
+                  ls "${check_package_libdir}/lib${check_package_generic_search_lib}."*  >/dev/null 2>&1
                   AS_IF([test $? -eq 0],
                         [check_package_generic_prefix_happy=1
                          $2_LDFLAGS="-L${check_package_libdir}"
                          AC_MSG_RESULT([found])],
                         [AC_MSG_RESULT([not found])])],
+                 [test -n "${check_package_prefix}"],
                  [check_package_generic_prefix_lib=0
                   check_package_generic_prefix_lib64=0
 
-                  ls ${check_package_prefix}/lib/lib${check_package_generic_search_lib}.*  >/dev/null 2>&1
+                  ls "${check_package_prefix}/lib/lib${check_package_generic_search_lib}."*  >/dev/null 2>&1
                   AS_IF([test $? -eq 0], [check_package_generic_prefix_lib=1])
-                  ls ${check_package_prefix}/lib64/lib${check_package_generic_search_lib}.*  >/dev/null 2>&1
+                  ls "${check_package_prefix}/lib64/lib${check_package_generic_search_lib}."*  >/dev/null 2>&1
                   AS_IF([test $? -eq 0], [check_package_generic_prefix_lib64=1])
 
                   AC_MSG_CHECKING([for $1 library (${check_package_generic_search_lib}) in ${check_package_prefix}])
@@ -617,17 +626,18 @@ AC_DEFUN([_OAC_CHECK_PACKAGE_GENERIC_PREFIX], [
 ${check_package_prefix}/lib64.  This has confused configure.  Please add --with-$1-libdir=PATH to configure to help
 disambiguate.])],
                                [check_package_generic_prefix_happy=1
-                                $2_LDFLAGS=-L${check_package_prefix}/lib
+                                $2_LDFLAGS="-L${check_package_prefix}/lib"
                                 AC_MSG_RESULT([found -- lib])])],
                         [test ${check_package_generic_prefix_lib} -eq 1],
                         [check_package_generic_prefix_happy=1
-                         $2_LDFLAGS=-L${check_package_prefix}/lib
+                         $2_LDFLAGS="-L${check_package_prefix}/lib"
                          AC_MSG_RESULT([found -- lib])],
                         [test $check_package_generic_prefix_lib64 -eq 1],
                         [check_package_generic_prefix_happy=1
-                         $2_LDFLAGS=-L${check_package_prefix}/lib64
+                         $2_LDFLAGS="-L${check_package_prefix}/lib64"
                          AC_MSG_RESULT([found -- lib64])],
-                        [AC_MSG_RESULT([not found])])])])
+                        [AC_MSG_RESULT([not found])])],
+                 [check_package_generic_prefix_happy=1])])
 
     AS_IF([test ${check_package_generic_prefix_happy} -eq 1], [$5])
     OAC_VAR_SCOPE_POP
@@ -658,7 +668,7 @@ AC_DEFUN([_OAC_CHECK_PACKAGE_VERIFY],[
           [AC_CHECK_HEADER([${check_package_verify_search_header}],
                            [check_package_verify_happy=1], [check_package_verify_happy=0])])
 
-    dnl Note that we use AC_CHEC_FUNC here instead of AC_CHECK_LIB, because we're pretty sure we've
+    dnl Note that we use AC_CHECK_FUNC here instead of AC_CHECK_LIB, because we're pretty sure we've
     dnl found the library already (and have added it to LIBS).  Now we're just trying to verify
     dnl that the library we found contains the bits we need.
     AS_IF([test ${check_package_verify_happy} -eq 1],

--- a/oac_init.m4
+++ b/oac_init.m4
@@ -8,7 +8,7 @@ dnl
 dnl $HEADER$
 
 dnl OAC is meant to be a "behind the scenes" kind of thing -- we don't
-dnl any any AC_DEFINEd or AC_SUBSTed symbols that begin with "OAC_".
+dnl want any AC_DEFINEd or AC_SUBSTed symbols that begin with "OAC_".
 m4_pattern_forbid([OAC_])
 
 dnl OAC_PUSH_PREFIX: Set a new prefix for AC_DEFINE/AC_SUBST names

--- a/oac_list.m4
+++ b/oac_list.m4
@@ -17,6 +17,7 @@ dnl Copyright (c) 2014      Intel, Inc. All rights reserved.
 dnl Copyright (c) 2015-2017 Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
 dnl Copyright (c) 2021-2022 Amazon.com, Inc. or its affiliates.  All Rights reserved.
+dnl Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -28,63 +29,51 @@ dnl OAC_UNIQ: Uniqify the string-separated words in the input variable
 dnl
 dnl 1 -> variable name to be uniq-ized
 AC_DEFUN([OAC_UNIQ],[
-OAC_VAR_SCOPE_PUSH([oac_uniq_name oac_uniq_done oac_uniq_i oac_uniq_found oac_uniq_count oac_uniq_newval oac_uniq_val])
+OAC_VAR_SCOPE_PUSH([oac_uniq_name oac_uniq_i oac_uniq_found oac_uniq_count oac_uniq_newval oac_uniq_val oac_uniq_eval oac_uniq_tmp])
 
 oac_uniq_name=$1
 
 # Go through each item in the variable and only keep the unique ones
 oac_uniq_count=0
 for oac_uniq_val in ${$1}; do
-    oac_uniq_done=0
     oac_uniq_i=1
     oac_uniq_found=0
 
-    # Loop over every token we've seen so far
-    oac_uniq_done="`expr ${oac_uniq_i} \> ${oac_uniq_count}`"
-    while test ${oac_uniq_found} -eq 0 && test ${oac_uniq_done} -eq 0; do
-        # Have we seen this token already?  Prefix the comparison with
-        # "x" so that "-Lfoo" values won't be cause an error.
-        oac_uniq_eval="expr x${oac_uniq_val} = x\${oac_uniq_array_$oac_uniq_i}"
-        oac_uniq_found=`eval ${oac_uniq_eval}`
-
-        # Check the ending condition
-        oac_uniq_done="`expr ${oac_uniq_i} \>= ${oac_uniq_count}`"
-
-        # Increment the counter
-        oac_uniq_i="`expr ${oac_uniq_i} + 1`"
+    # Loop over every token we've seen so far; use -le so we avoid
+    # the > redirection ambiguity when the comparison falls to expr.
+    while test ${oac_uniq_found} -eq 0 && test ${oac_uniq_i} -le ${oac_uniq_count}; do
+        # Have we seen this token already?  Use a temp var so we avoid
+        # eval "[ ... ]": M4 treats [ and ] as quoting characters and
+        # would silently strip the shell-test brackets on expansion.
+        eval "oac_uniq_tmp=\${oac_uniq_array_$oac_uniq_i}"
+        AS_IF([test "x${oac_uniq_val}" = "x${oac_uniq_tmp}"], [oac_uniq_found=1])
+        AS_VAR_ARITH([oac_uniq_i], [$oac_uniq_i + 1])
     done
 
-    # If we didn't find the token, add it to the "array"
+    # If we didn't find the token, add it to the "array".
+    # oac_uniq_i is now oac_uniq_count+1 when found==0.
     if test ${oac_uniq_found} -eq 0; then
-        oac_uniq_eval="oac_uniq_array_${oac_uniq}_i=${oac_uniq_val}"
-        eval ${oac_uniq_eval}
-        oac_uniq_count="`expr ${oac_uniq_count} + 1`"
-    else
-        oac_uniq_i="`expr ${oac_uniq_i} - 1`"
+        eval "oac_uniq_array_${oac_uniq_i}=\${oac_uniq_val}"
+        AS_VAR_ARITH([oac_uniq_count], [$oac_uniq_count + 1])
     fi
 done
 
 # Take all the items in the "array" and assemble them back into a
 # single variable
 oac_uniq_i=1
-oac_uniq_done="`expr ${oac_uniq_i} \> ${oac_uniq_count}`"
 oac_uniq_newval=
-while test ${oac_uniq_done} -eq 0; do
-    oac_uniq_eval="oac_uniq_newval=\"${oac_uniq_newval} \${oac_uniq_array_$oac_uniq_i}\""
-    eval ${oac_uniq_eval}
+while test ${oac_uniq_i} -le ${oac_uniq_count}; do
+    eval "oac_uniq_tmp=\${oac_uniq_array_$oac_uniq_i}"
+    OAC_APPEND([oac_uniq_newval], [${oac_uniq_tmp}])
 
     oac_uniq_eval="unset oac_uniq_array_${oac_uniq_i}"
     eval ${oac_uniq_eval}
 
-    oac_uniq_done="`expr ${oac_uniq_i} \>= ${oac_uniq_count}`"
-    oac_uniq_i="`expr ${oac_uniq_i} + 1`"
+    AS_VAR_ARITH([oac_uniq_i], [$oac_uniq_i + 1])
 done
 
 # Done; do the assignment
-
-oac_uniq_newval="`echo ${oac_uniq_newval}`"
-oac_uniq_eval="${oac_uniq_name}=\"${oac_uniq_newval}\""
-eval ${oac_uniq_eval}
+eval "${oac_uniq_name}=\${oac_uniq_newval}"
 
 OAC_VAR_SCOPE_POP
 ])dnl
@@ -145,14 +134,15 @@ dnl
 dnl This macro assumes a space separated list.
 AC_DEFUN([OAC_FLAGS_APPEND_UNIQ],
 [OAC_ASSERT_LITERAL([$1])
-OAC_VAR_SCOPE_PUSH([oac_list_prefix oac_list_append oac_list_arg oac_list_val])
+OAC_VAR_SCOPE_PUSH([oac_list_append oac_list_arg oac_list_val])
 for oac_list_arg in $2; do
     oac_list_append=1
     AS_CASE([${oac_list_arg}],
             [-I*|-L*|-l*],
             [for oac_list_val in ${$1}; do
-                 AS_IF([test "x${oal_list_val}" = "x${oac_list_arg}"],
-                       [oac_list_append=0])
+                 AS_IF([test "x${oac_list_val}" = "x${oac_list_arg}"],
+                       [oac_list_append=0
+                        break])
              done])
     AS_IF([test ${oac_list_append} -eq 1],
           [OAC_APPEND([$1], [$oac_list_arg])])
@@ -174,18 +164,22 @@ dnl
 dnl This macro assumes a space separated list.
 AC_DEFUN([OAC_FLAGS_PREPEND_UNIQ],
 [OAC_ASSERT_LITERAL([$1])
-OAC_VAR_SCOPE_PUSH([oac_list_prefix oac_list_prepend oac_list_arg oac_list_val])
+OAC_VAR_SCOPE_PUSH([oac_list_prepend oac_list_arg oac_list_val oac_list_new])
+oac_list_new=
 for oac_list_arg in $2; do
     oac_list_prepend=1
     AS_CASE([${oac_list_arg}],
             [-I*|-L*|-l*],
             [for oac_list_val in ${$1}; do
-                 AS_IF([test "x${oal_list_val}" = "x${oac_list_arg}"],
-                       [oac_list_prepend=0])
+                 AS_IF([test "x${oac_list_val}" = "x${oac_list_arg}"],
+                       [oac_list_prepend=0
+                        break])
              done])
     AS_IF([test ${oac_list_prepend} -eq 1],
-           [AS_IF([test -z "${$1}"], [$1="$2"], [$1="$2 ${$1}"])])
+          [OAC_APPEND([oac_list_new], [${oac_list_arg}])])
 done
+AS_IF([test -n "${oac_list_new}"],
+      [AS_IF([test -z "${$1}"], [$1="${oac_list_new}"], [$1="${oac_list_new} ${$1}"])])
 OAC_VAR_SCOPE_POP
 ])dnl
 
@@ -217,7 +211,8 @@ for oac_list_arg in $2; do
             [oac_list_append=1
              for oac_list_val in ${$1} ; do
                  AS_IF([test "x${oac_list_val}" = "x${oac_list_arg}"],
-                       [oac_list_append=0])
+                       [oac_list_append=0
+                        break])
              done
              AS_IF([test ${oac_list_append} -eq 1],
                    [OAC_APPEND([$1], [${oac_list_arg}])])],

--- a/oac_log.m4
+++ b/oac_log.m4
@@ -44,14 +44,14 @@ dnl OAC_LOG_FILE: Dump the specified file into config.log
 dnl
 dnl 1 -> filename of file to dump into config.log
 AC_DEFUN([OAC_LOG_FILE],
-[AS_IF([test -n "$1" && test -f "$1"], [cat $1 >&AS_MESSAGE_LOG_FD])])dnl
+[AS_IF([test -n "$1" && test -f "$1"], [cat "$1" >&AS_MESSAGE_LOG_FD])])dnl
 
 
 dnl OAC_LOG_COMMAND: Run command, logging output, and checking status
 dnl
 dnl 1 -> command to execute
 dnl 2 -> action if successful
-dnl 3 -> action if if fail
+dnl 3 -> action if fail
 AC_DEFUN([OAC_LOG_COMMAND],[
 OAC_LOG_MSG([$1])
 $1 1>&AS_MESSAGE_LOG_FD 2>&1

--- a/oac_setup_sphinx.m4
+++ b/oac_setup_sphinx.m4
@@ -2,7 +2,7 @@ dnl -*- autoconf -*-
 dnl
 dnl Copyright (c) 2020-2022 Cisco Systems, Inc.  All rights reserved.
 dnl Copyright (c) 2024 Jeffrey M. Squyres.  All rights reserved.
-dnl Copyright (c) 2025      NVIDIA Corporation.  All rights reserved.
+dnl Copyright (c) 2025-2026 NVIDIA Corporation.  All rights reserved.
 dnl
 dnl $COPYRIGHT$
 dnl
@@ -33,7 +33,7 @@ dnl "make dist" should be disabled, suitable for emitting via
 dnl AC_MSG_WARN.
 AC_DEFUN([OAC_SETUP_SPHINX],[
     OAC_ASSERT_PREFIX_DEFINED([$0])
-    OAC_VAR_SCOPE_PUSH([oac_summary_msg oac_sphinx_result oac_install_docs oac_sphinx_target_version oac_sphinx_found_version])
+    OAC_VAR_SCOPE_PUSH([oac_summary_msg oac_sphinx_result oac_install_docs oac_sphinx_target_version oac_sphinx_found_version oac_startdir oac_tmpdir oac_happy])
 
     # This option is probably only helpful to developers: have
     # configure fail if Sphinx is not found (i.e., if you don't have
@@ -60,7 +60,7 @@ AC_DEFUN([OAC_SETUP_SPHINX],[
     # If we found Sphinx, check to ensure that it's a recent enough
     # version.
     AS_IF([test -n "$SPHINX_BUILD"],
-          [[oac_sphinx_target_version=`sed -n -e 's/sphinx[><=]*\([0-9\.]\)/\1/p' $srcdir/docs/requirements.txt`]
+          [[oac_sphinx_target_version=`sed -n -e 's/sphinx[><=]*\([0-9][0-9.]*\)/\1/p' "$srcdir/docs/requirements.txt" | head -1`]
            # Some older versions of Sphinx (e.g., Sphinx v1.1.3 in
            # RHEL 7):
            #
@@ -75,7 +75,7 @@ AC_DEFUN([OAC_SETUP_SPHINX],[
            # In the case where --version *is* recognized, all the
            # additional processing is harmless and we still end up
            # with the Sphinx version number.
-           oac_sphinx_found_version=`$SPHINX_BUILD --version 2>&1 | head -n 1 | cut -d\  -f2 | sed -e 's/^v//'`
+           oac_sphinx_found_version=`"$SPHINX_BUILD" --version 2>&1 | head -n 1 | cut -d\  -f2 | sed -e 's/^v//'`
            AC_MSG_CHECKING([if Sphinx version is high enough ($oac_sphinx_found_version >= $oac_sphinx_target_version)])
            AS_VERSION_COMPARE([$oac_sphinx_found_version],
                               [$oac_sphinx_target_version],
@@ -116,15 +116,15 @@ EOF
            # Try to render this trivial RST project as both HTML and
            # man pages and see if it works.
            oac_happy=0
-           OAC_LOG_COMMAND([$SPHINX_BUILD -M html . build-html],
-               [OAC_LOG_COMMAND([$SPHINX_BUILD -M man . build-man],
+           OAC_LOG_COMMAND(["$SPHINX_BUILD" -M html . build-html],
+               [OAC_LOG_COMMAND(["$SPHINX_BUILD" -M man . build-man],
                    [oac_happy=1])])
            AS_IF([test $oac_happy -eq 1],
                  [AC_MSG_RESULT([found])],
                  [SPHINX_BUILD=
                   AC_MSG_RESULT([not found])])
 
-           cd $oac_startdir
+           cd "$oac_startdir"
            rm -rf $oac_tmpdir
           ])
 

--- a/oac_summary.m4
+++ b/oac_summary.m4
@@ -7,6 +7,7 @@ dnl Copyright (c) 2016      Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
 dnl Copyright (c) 2022      Amazon.com, Inc. or its affiliates.  All Rights reserved.
 dnl Copyright (c) 2022      IBM Corporation.  All rights reserved.
+dnl Copyright (c) 2026      NVIDIA Corporation.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -83,13 +84,13 @@ dnl blank : emit the summary to configure's default (i.e., AS_MESSAGE_FD)
 dnl
 dnl Other values will cause an m4_fatal error.
 AC_DEFUN([OAC_SUMMARY_PRINT],[
-    OAC_VAR_SCOPE_PUSH([oac_summary_section oac_summary_section_name])
-    m4_define([oac_summary_print_fd],
-              [m4_if([$1], [stderr], [2],
-                     [$1], [stdout], [1],
-                     [$1], [], [AS_MESSAGE_FD],
-                     [m4_fatal([You must pass stdin, stderr, or nothing to $0])])
-              ])
+    OAC_VAR_SCOPE_PUSH([oac_summary_section oac_summary_section_name oac_summary_section_value])
+    m4_pushdef([oac_summary_print_fd],
+               [m4_if([$1], [stderr], [2],
+                      [$1], [stdout], [1],
+                      [$1], [], [AS_MESSAGE_FD],
+                      [m4_fatal([You must pass stdout, stderr, or nothing to $0])])
+               ])
 
     for oac_summary_section in ${oac_summary_sections} ; do
         AS_VAR_COPY([oac_summary_section_name], [oac_summary_section_${oac_summary_section}_name])
@@ -100,6 +101,6 @@ AC_DEFUN([OAC_SUMMARY_PRINT],[
         echo " " >&oac_summary_print_fd
     done
 
-    m4_undefine([oac_summary_print_fd])
+    m4_popdef([oac_summary_print_fd])
     OAC_VAR_SCOPE_POP
 ])

--- a/oac_var_scope.m4
+++ b/oac_var_scope.m4
@@ -87,7 +87,7 @@ oac_var_scope_push ${LINENO} $1
 
 dnl OAC_VAR_SCOPE_POP: pop off the current variable scope
 dnl
-dnl Unset the last set of variables set in OAC_VAR_SCOPE_POP.  Every call to
+dnl Unset the last set of variables set in OAC_VAR_SCOPE_PUSH.  Every call to
 dnl OAC_VAR_SCOPE_PUSH should have a matched call to this macro.
 AC_DEFUN([OAC_VAR_SCOPE_POP],[
 AC_REQUIRE([OAC_VAR_SCOPE_INIT])dnl


### PR DESCRIPTION
oac_list.m4:
- Fix OAC_UNIQ array key (used undefined ${oac_uniq} instead of ${oac_uniq_i})
- Fix typo oal_list_val → oac_uniq_val in FLAGS_APPEND/PREPEND_UNIQ
- Fix OAC_FLAGS_PREPEND_UNIQ prepending entire input list instead of current item
- Replace all expr arithmetic with $(( )) to avoid subprocess forks
- Make all eval strings space-safe by deferring value expansion via \${var}
- Replace expr string comparison with shell [ ] builtin (space-safe, no fork)
- Add break on match in all three inner dedup loops
- Remove dead oac_list_prefix variable from two scope pushes
- Add missing oac_uniq_eval and oac_uniq_tmp to OAC_UNIQ scope push

oac_check_package.m4:
- Fix cache variable name mismatch (check_package_cv_ vs oac_cv_check_package_)
- Fix $2_PC_MODULES lost on warm cache; unset it on verification failure
- Fix $1_CPPFLAGS/$1_LDFLAGS → $2_CPPFLAGS/$2_LDFLAGS in no-prefix path
- Replace m4_define with m4_pushdef/m4_popdef for pcname and wrapper_compiler_name
- Add check_package_type to scope push; remove dead check_package_pcfilename
- Add prefix_happy/lib/lib64 to _OAC_CHECK_PACKAGE_GENERIC_PREFIX scope push
- Quote all path expansions: test -r, $2_LDFLAGS=-L, ls globs, PKG_CONFIG $1, wrapper $1
- Replace echo|cut|sed pipelines with parameter expansion (${var%% *}, ${var#-l})
- Fix $2_LIBS missing braces; remove spurious [1] args from OAC_LOG_MSG calls

oac_summary.m4:
- Fix stdin → stdout in m4_fatal error message
- Add oac_summary_section_value to OAC_SUMMARY_PRINT scope push
- Replace m4_define/m4_undefine with m4_pushdef/m4_popdef for oac_summary_print_fd

oac_check_os_flavors.m4:
- Add missing brackets around OAC_CHECK_OS_FLAVOR_SPECIFIC in AS_IF
- Fully bracket both AM_CONDITIONAL calls

oac_setup_sphinx.m4:
- Fix sed regex to capture full version string (not just first digit)
- Quote $SPHINX_BUILD in all three invocations; quote $srcdir path; quote cd target
- Add oac_startdir, oac_tmpdir, oac_happy to scope push
- Pipe sed through head -1 to handle multiple matching lines in requirements.txt

oac_log.m4: Quote $1 in OAC_LOG_FILE cat invocation; fix double "if" typo in docstring
oac_var_scope.m4: Fix OAC_VAR_SCOPE_POP docstring self-reference
oac_init.m4: Fix duplicate word in comment
oac_summary.m4: Fix "stdin" → "stdout" in error message