### PR TITLE
oac_check_package: trigger prefix search when --with-<pkg>-incdir/libdir are given

### DIFF
--- a/oac_check_package.m4
+++ b/oac_check_package.m4
@@ -541,7 +541,7 @@ AC_DEFUN([_OAC_CHECK_PACKAGE_GENERIC], [
     OAC_VAR_SCOPE_PUSH([check_package_generic_happy check_package_generic_lib])
     check_package_generic_happy=0
 
-    AS_IF([test -n "${check_package_prefix}"],
+    AS_IF([test -n "${check_package_prefix}" || test -n "${check_package_incdir}" || test -n "${check_package_libdir}"],
           [_OAC_CHECK_PACKAGE_GENERIC_PREFIX([$1], [$2], [$3], [$4], [check_package_generic_happy=1])],
           [AC_MSG_NOTICE([Searching for $1 in default search paths])
            $1_CPPFLAGS=


### PR DESCRIPTION
_OAC_CHECK_PACKAGE_GENERIC only invoked _OAC_CHECK_PACKAGE_GENERIC_PREFIX when --with-<package>=PATH was provided (setting check_package_prefix). If the user specified only --with-<package>-incdir and/or --with-<package>-libdir (e.g. for packages with no common install root), check_package_prefix was empty and the search fell through to the default system paths, ignoring the explicit locations entirely.

_OAC_CHECK_PACKAGE_GENERIC_PREFIX already handles check_package_incdir and check_package_libdir independently of check_package_prefix, so the fix is to also enter the prefix-based search when either of those are set.

Fixes open-mpi/oac#14.